### PR TITLE
Add multi-MCP server support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,8 +82,11 @@ OLLAMA_MAX_TURNS=20
 TOOL_CACHE_SIZE=3
 
 # =============================================================================
-# n8n MCP Server
+# MCP Server Configuration
 # =============================================================================
+# n8n is the foundational MCP server, configured here in .env
+# Additional MCP servers can be configured in mcp_servers.json (see mcp_servers.json.example)
+
 # n8n MCP endpoint URL (required for workflow tools)
 N8N_MCP_URL=http://192.168.1.100:5678/mcp-server/http
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ n8n-workflows/config.env
 # Runtime settings (user-specific)
 settings.json
 prompt/custom.md
+mcp_servers.json
+
+# Database files
+*.db
 
 # Models (large files - download separately)
 *.onnx

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,7 @@ services:
       - caal-memory:/app/data
       - ./settings.json:/app/settings.json  # Runtime settings (created on first save)
       - ./prompt:/app/prompt  # Prompt files (custom.md is gitignored)
+      - ./mcp_servers.json:/app/mcp_servers.json  # Additional MCP servers (optional)
     networks:
       - caal-network
     depends_on:

--- a/mcp_servers.json.example
+++ b/mcp_servers.json.example
@@ -1,0 +1,12 @@
+{
+  "description": "Additional MCP servers for CAAL (n8n is configured in .env)",
+  "servers": [
+    {
+      "name": "home_assistant",
+      "url": "http://homeassistant.local:8123/api/mcp",
+      "token": "your_long_lived_access_token",
+      "transport": "streamable_http",
+      "timeout": 10.0
+    }
+  ]
+}

--- a/src/caal/integrations/mcp_loader.py
+++ b/src/caal/integrations/mcp_loader.py
@@ -1,11 +1,14 @@
 """MCP Server Configuration Loader
 
-Loads MCP server definitions from environment variables.
+Loads MCP server definitions from environment variables and optional JSON config file.
 """
 
-import os
+import json
 import logging
+import os
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
 
 from livekit.agents import mcp
 
@@ -18,34 +21,81 @@ class MCPServerConfig:
     name: str
     url: str
     auth_token: str | None = None
+    transport: Literal["sse", "streamable_http"] | None = None
     timeout: float = 10.0
 
 
 def load_mcp_config() -> list[MCPServerConfig]:
-    """Load MCP server configurations from environment variables.
+    """Load MCP server configurations from env vars and optional JSON file.
+
+    n8n is loaded from environment variables (foundational).
+    Additional MCP servers can be configured in mcp_servers.json.
 
     Environment variables:
-        N8N_MCP_URL: n8n MCP server URL (required)
+        N8N_MCP_URL: n8n MCP server URL
         N8N_MCP_TOKEN: Bearer token for n8n (optional)
         N8N_MCP_TIMEOUT: Request timeout in seconds (optional, default 10.0)
+
+    JSON file (mcp_servers.json):
+        {
+            "servers": [
+                {
+                    "name": "server_name",
+                    "url": "http://...",
+                    "token": "optional_token",
+                    "transport": "sse" | "streamable_http",
+                    "timeout": 10.0
+                }
+            ]
+        }
 
     Returns:
         List of MCPServerConfig objects
     """
     servers = []
 
-    # n8n MCP Server
+    # 1. n8n MCP Server from env (foundational)
     n8n_url = os.environ.get("N8N_MCP_URL")
     if n8n_url:
         servers.append(MCPServerConfig(
-            name="n8n-workflows",
+            name="n8n",
             url=n8n_url,
             auth_token=os.environ.get("N8N_MCP_TOKEN"),
+            transport="streamable_http",  # n8n uses /http suffix which needs explicit transport
             timeout=float(os.environ.get("N8N_MCP_TIMEOUT", "10.0")),
         ))
-        logger.debug(f"Loaded MCP server config: n8n-workflows ({n8n_url})")
+        logger.debug(f"Loaded MCP server config: n8n ({n8n_url})")
     else:
-        logger.warning("N8N_MCP_URL not set - no MCP tools will be available")
+        logger.info("N8N_MCP_URL not set - n8n MCP tools will not be available")
+
+    # 2. Additional MCP servers from JSON config (optional)
+    config_path = Path("mcp_servers.json")
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                data = json.load(f)
+                for server in data.get("servers", []):
+                    name = server.get("name")
+                    url = server.get("url")
+                    if not name or not url:
+                        logger.warning(f"Skipping MCP server with missing name or url: {server}")
+                        continue
+
+                    servers.append(MCPServerConfig(
+                        name=name,
+                        url=url,
+                        auth_token=server.get("token"),
+                        transport=server.get("transport"),
+                        timeout=server.get("timeout", 10.0),
+                    ))
+                    logger.debug(f"Loaded MCP server config from JSON: {name} ({url})")
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse mcp_servers.json: {e}")
+        except Exception as e:
+            logger.error(f"Failed to load mcp_servers.json: {e}")
+
+    if not servers:
+        logger.warning("No MCP servers configured - no MCP tools will be available")
 
     return servers
 
@@ -75,15 +125,17 @@ async def initialize_mcp_servers(
                 timeout=config.timeout,
             )
 
-            # Force streamable HTTP transport for URLs ending in /http (like n8n)
-            # LiveKit's MCPServerHTTP only auto-detects streamable HTTP for URLs ending in /mcp
-            if config.url.endswith("/http"):
+            # Set transport type if specified
+            # Newer LiveKit versions use transport_type param, older use private attr
+            if config.transport == "streamable_http":
                 server._use_streamable_http = True
-                logger.debug(f"Forcing streamable HTTP transport for {config.name}")
+            elif config.transport == "sse":
+                server._use_streamable_http = False
+            # If transport not specified, let LiveKit auto-detect from URL
 
             await server.initialize()
             servers[config.name] = server
-            logger.debug(f"Initialized MCP server: {config.name}")
+            logger.info(f"Initialized MCP server: {config.name}")
 
         except Exception as e:
             logger.error(f"Failed to initialize MCP server {config.name}: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- Adds support for multiple MCP servers via `mcp_servers.json` config file
- n8n remains configured in `.env` as the foundational MCP server
- Additional servers (Home Assistant, Memento, etc.) can be added via JSON
- Tools from non-n8n servers are prefixed with `server_name__` to avoid collisions
- Supports both SSE and streamable_http transports

## Changes
- `mcp_loader.py`: Load configs from both env vars and JSON file
- `voice_agent.py`: Pass all MCP servers to agent
- `ollama_node.py`: Multi-server tool discovery and routing
- `docker-compose.yaml`: Mount mcp_servers.json into container
- Added `mcp_servers.json.example` for reference

## Testing
- Tested with Home Assistant MCP (15 tools)
- Tested with Memento memory server (10 tools)
- Backward compatible: no JSON file = existing n8n-only behavior

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)