### PR TITLE
Fix RTX 5080 (Blackwell/sm_120) support for Kokoro TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,8 @@ Both use the same `--profile https` and nginx for TLS termination.
 
 2. **Wake Word Models**: The Python `.ppn` models don't work in browser - you need the Web (WASM) version from Picovoice.
 
+3. **RTX 50 Series (Blackwell) Support**: Kokoro TTS requires `v0.2.4-master` or later for RTX 5080/5090 (sm_120) support. This is already configured in `docker-compose.yaml`.
+
 ## Related Projects
 
 - [LiveKit Agents](https://github.com/livekit/agents) - Voice agent framework

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,8 +122,10 @@ services:
   # ===========================================================================
   # Kokoro - TTS (remsky/kokoro-fastapi)
   # ===========================================================================
+  # Using v0.2.4-master for RTX 50 series (Blackwell/sm_120) GPU support
+  # See: https://github.com/remsky/Kokoro-FastAPI/releases/tag/v0.2.4-master
   kokoro:
-    image: ghcr.io/remsky/kokoro-fastapi-gpu:latest
+    image: ghcr.io/remsky/kokoro-fastapi-gpu:v0.2.4-master
     container_name: caal-kokoro
     ports:
       - "${KOKORO_PORT:-8880}:8880"


### PR DESCRIPTION
Update Kokoro image from :latest to :v0.2.4-master which includes
PyTorch 2.7.1+cu128 with RTX 50 series GPU support.

Fixes #4