### PR TITLE
Add startup script and documentation for Apple Silicon

### DIFF
--- a/README-APPLE.md
+++ b/README-APPLE.md
@@ -1,0 +1,236 @@
+# CAAL on Apple Silicon (M1/M2/M3/M4)
+
+This guide covers running CAAL on Apple Silicon Macs using Metal-accelerated STT/TTS via [mlx-audio](https://github.com/Blaizzy/mlx-audio).
+
+## Why a Separate Setup?
+
+Docker on macOS cannot access the Metal GPU. To get hardware acceleration for Speech-to-Text and Text-to-Speech, these services must run natively on the host while the rest of the stack runs in Docker.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  macOS Host                                             │
+│                                                         │
+│  ┌─────────────┐  ┌─────────────┐                       │
+│  │  mlx-audio  │  │   Ollama    │                       │
+│  │ (STT + TTS) │  │   (LLM)     │                       │
+│  │   :8001     │  │  :11434     │                       │
+│  │  [Metal]    │  │   [MPS]     │                       │
+│  └──────┬──────┘  └──────┬──────┘                       │
+│         │                │                              │
+│  ┌──────┴────────────────┴──────────────────────────┐   │
+│  │           Docker (ARM64)                         │   │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐        │   │
+│  │  │ Frontend │  │ LiveKit  │  │  Agent   │        │   │
+│  │  │  :3000   │  │  :7880   │  │  :8889   │        │   │
+│  │  └──────────┘  └──────────┘  └──────────┘        │   │
+│  └──────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+### 1. Ollama
+
+Install and pull a model:
+
+```bash
+brew install ollama
+ollama pull ministral-3:8b
+ollama serve  # Keep running or use: brew services start ollama
+```
+
+> **Note:** `ministral-3:8b` is recommended for its good tool-calling support and low latency. Requires Ollama 0.13.3+.
+
+### 2. mlx-audio
+
+```bash
+pip install "mlx-audio[all]"
+```
+
+### 3. Docker Desktop
+
+Download from [docker.com](https://www.docker.com/products/docker-desktop/) and ensure it's running.
+
+### 4. n8n (Optional)
+
+If you want workflow integrations, you need n8n with MCP enabled:
+1. Run n8n (Docker or native)
+2. Go to **Settings > MCP Access > Enable MCP**
+3. Copy the access token
+
+## Installation
+
+### 1. Clone and Configure
+
+```bash
+git clone https://github.com/CoreWorxLab/caal.git
+cd caal
+cp .env.example .env
+```
+
+### 2. Edit `.env`
+
+Update these values:
+
+```bash
+# Your Mac's LAN IP (find with: ipconfig getifaddr en0)
+CAAL_HOST_IP=192.168.1.100
+
+# Ollama (host.docker.internal lets Docker reach your Mac)
+OLLAMA_HOST=http://host.docker.internal:11434
+OLLAMA_MODEL=ministral-3:8b
+
+# mlx-audio runs on port 8001 (8000 is often used by other services)
+MLX_AUDIO_URL=http://host.docker.internal:8001
+
+# n8n MCP (optional - if you have n8n running)
+N8N_MCP_URL=http://host.docker.internal:5678/mcp-server/http
+N8N_MCP_TOKEN=your_token_here
+
+# Suppress Docker warnings
+HTTPS_DOMAIN=
+```
+
+## Usage
+
+### Start CAAL
+
+```bash
+./start-apple.sh
+```
+
+This will:
+1. Check that Ollama is running
+2. Start mlx-audio server (Metal-accelerated)
+3. Preload Whisper (STT) and Kokoro (TTS) models
+4. Start Docker services (LiveKit, Agent, Frontend)
+
+Output:
+```
+    ███╗   ███╗██╗     ██╗  ██╗       ██████╗ █████╗  █████╗ ██╗
+    ████╗ ████║██║     ╚██╗██╔╝      ██╔════╝██╔══██╗██╔══██╗██║
+    ██╔████╔██║██║      ╚███╔╝ █████╗██║     ███████║███████║██║
+    ██║╚██╔╝██║██║      ██╔██╗ ╚════╝██║     ██╔══██║██╔══██║██║
+    ██║ ╚═╝ ██║███████╗██╔╝ ██╗      ╚██████╗██║  ██║██║  ██║███████╗
+    ╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝       ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+
+  Voice Assistant for Apple Silicon
+
+[CAAL] Starting CAAL...
+
+[CAAL] Checking Ollama... ✓
+[CAAL] Starting mlx-audio server... ✓ (PID 12345)
+
+[CAAL] Preloading models (first time may take a few minutes)...
+
+[CAAL] Loading Whisper STT ⠹
+[CAAL] ✓ Whisper STT loaded
+[CAAL] Loading Kokoro TTS ⠧
+[CAAL] ✓ Kokoro TTS loaded
+
+══════════════════════════════════════════════════════════
+  CAAL is ready!
+══════════════════════════════════════════════════════════
+
+  Web interface:  http://localhost:3000
+  Stop command:   ./start-apple.sh --stop
+```
+
+### Stop CAAL
+
+```bash
+./start-apple.sh --stop
+```
+
+### View Logs
+
+```bash
+# mlx-audio logs
+tail -f /tmp/caal-mlx-audio.log
+
+# Agent logs
+docker compose -f docker-compose.apple.yaml logs -f agent
+```
+
+## First Run
+
+The first startup takes longer because:
+- mlx-audio downloads Whisper (~1.5GB) and Kokoro (~300MB) models
+- Docker builds the Agent and Frontend images
+
+Subsequent starts are much faster as everything is cached.
+
+## Troubleshooting
+
+### "Ollama is not accessible"
+
+Make sure Ollama is running:
+```bash
+ollama serve
+# Or check if it's already running:
+curl http://localhost:11434/api/tags
+```
+
+### "mlx-audio failed to start"
+
+Check if port 8001 is already in use:
+```bash
+lsof -i :8001
+```
+
+If another service uses it, either stop that service or change the port in both `start-apple.sh` and `.env`.
+
+### Voice not working in browser
+
+On HTTP (not HTTPS), browsers only allow microphone access from `localhost`. Access CAAL at:
+- ✅ `http://localhost:3000` (microphone works)
+- ❌ `http://192.168.1.100:3000` (text only, no microphone)
+
+For voice from other devices, see the HTTPS setup in the main README.
+
+### Agent can't connect to mlx-audio
+
+Verify Docker can reach your Mac:
+```bash
+docker run --rm alpine ping -c1 host.docker.internal
+```
+
+### Slow first response
+
+Normal - Ollama may need to load the model into memory. Subsequent responses are faster. To keep the model loaded:
+```bash
+OLLAMA_KEEP_ALIVE=24h ollama serve
+```
+
+## Models
+
+### STT (Speech-to-Text)
+- Default: `mlx-community/whisper-medium-mlx`
+- Alternatives: `whisper-tiny-mlx`, `whisper-small-mlx`, `whisper-large-v3-turbo-mlx`
+
+### TTS (Text-to-Speech)
+- Default: `prince-canuma/Kokoro-82M`
+- Voice: `am_puck` (configurable in `.env` as `TTS_VOICE`)
+
+### LLM
+- Default: `ministral-3:8b` (good tool-calling, low latency)
+- Alternative: `llama3.1:8b`, `qwen2.5:7b`
+- Any Ollama model works, but 7-8B models offer the best latency/quality balance
+
+## Memory Usage
+
+With default models on a 24GB Mac:
+- mlx-audio (Whisper + Kokoro): ~2-3GB
+- Ollama (ministral-3:8b): ~5GB
+- Docker services: ~1GB
+
+Total: ~8-9GB, leaving plenty of headroom.
+
+## Updating
+
+```bash
+git pull
+docker compose -f docker-compose.apple.yaml build
+./start-apple.sh --stop
+./start-apple.sh
+```

--- a/start-apple.sh
+++ b/start-apple.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# CAAL Startup Script for Apple Silicon
+# Usage: ./start-apple.sh [--stop]
+
+set -e
+cd "$(dirname "$0")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[CAAL]${NC} $1"; }
+warn() { echo -e "${YELLOW}[CAAL]${NC} $1"; }
+error() { echo -e "${RED}[CAAL]${NC} $1"; }
+
+MLX_PID_FILE="/tmp/caal-mlx-audio.pid"
+MLX_LOG_FILE="/tmp/caal-mlx-audio.log"
+
+banner() {
+    echo -e "${CYAN}${BOLD}"
+    cat << 'EOF'
+    ███╗   ███╗██╗     ██╗  ██╗       ██████╗ █████╗  █████╗ ██╗
+    ████╗ ████║██║     ╚██╗██╔╝      ██╔════╝██╔══██╗██╔══██╗██║
+    ██╔████╔██║██║      ╚███╔╝ █████╗██║     ███████║███████║██║
+    ██║╚██╔╝██║██║      ██╔██╗ ╚════╝██║     ██╔══██║██╔══██║██║
+    ██║ ╚═╝ ██║███████╗██╔╝ ██╗      ╚██████╗██║  ██║██║  ██║███████╗
+    ╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝       ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+EOF
+    echo -e "${NC}"
+    echo -e "  ${BOLD}Voice Assistant for Apple Silicon${NC}"
+    echo ""
+}
+
+# Progress bar function
+# Usage: progress_bar "message" current total
+progress_bar() {
+    local msg="$1"
+    local current="$2"
+    local total="$3"
+    local width=30
+    local percent=$((current * 100 / total))
+    local filled=$((current * width / total))
+    local empty=$((width - filled))
+
+    printf "\r${GREEN}[CAAL]${NC} %s [" "$msg"
+    printf "%${filled}s" | tr ' ' '█'
+    printf "%${empty}s" | tr ' ' '░'
+    printf "] %3d%%" "$percent"
+}
+
+# Load a model with progress feedback
+load_model() {
+    local model="$1"
+    local name="$2"
+
+    curl -s -X POST "http://localhost:8001/v1/models?model_name=$model" > /dev/null &
+    local pid=$!
+
+    local spin=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+    local i=0
+
+    while kill -0 $pid 2>/dev/null; do
+        printf "\r${GREEN}[CAAL]${NC} Loading %s ${CYAN}%s${NC} " "$name" "${spin[$i]}"
+        i=$(( (i + 1) % 10 ))
+        sleep 0.1
+    done
+
+    wait $pid
+    printf "\r${GREEN}[CAAL]${NC} ✓ %s loaded                    \n" "$name"
+}
+
+stop_all() {
+    echo ""
+    log "Stopping CAAL..."
+
+    # Stop Docker
+    log "Stopping Docker containers..."
+    docker compose -f docker-compose.apple.yaml down || true
+
+    # Stop mlx-audio
+    if [ -f "$MLX_PID_FILE" ]; then
+        PID=$(cat "$MLX_PID_FILE")
+        if kill -0 "$PID" 2>/dev/null; then
+            kill "$PID" 2>/dev/null || true
+            log "mlx-audio stopped (PID $PID)"
+        fi
+        rm -f "$MLX_PID_FILE"
+    fi
+
+    echo ""
+    log "CAAL stopped."
+    exit 0
+}
+
+# Handle --stop flag
+if [ "$1" == "--stop" ]; then
+    stop_all
+fi
+
+banner
+log "Starting CAAL..."
+echo ""
+
+# Check Ollama
+printf "${GREEN}[CAAL]${NC} Checking Ollama... "
+if ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+    echo ""
+    error "Ollama is not accessible on localhost:11434"
+    error "Run: ollama serve"
+    exit 1
+fi
+echo -e "${GREEN}✓${NC}"
+
+# Check if mlx-audio is already running
+MLX_RUNNING=false
+if [ -f "$MLX_PID_FILE" ]; then
+    PID=$(cat "$MLX_PID_FILE")
+    if kill -0 "$PID" 2>/dev/null; then
+        MLX_RUNNING=true
+        log "✓ mlx-audio already running (PID $PID)"
+    fi
+fi
+
+# Start mlx-audio if not running
+if [ "$MLX_RUNNING" = false ]; then
+    printf "${GREEN}[CAAL]${NC} Starting mlx-audio server... "
+
+    # Start in background
+    nohup python3 -m mlx_audio.server --host 0.0.0.0 --port 8001 > "$MLX_LOG_FILE" 2>&1 &
+    MLX_PID=$!
+    echo $MLX_PID > "$MLX_PID_FILE"
+
+    # Wait for server to be ready
+    for i in {1..30}; do
+        if curl -s http://localhost:8001/docs > /dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+
+    if ! curl -s http://localhost:8001/docs > /dev/null 2>&1; then
+        echo ""
+        error "mlx-audio failed to start. Logs: $MLX_LOG_FILE"
+        exit 1
+    fi
+
+    echo -e "${GREEN}✓${NC} (PID $MLX_PID)"
+    echo ""
+
+    # Preload models with progress
+    log "Preloading models (first time may take a few minutes)..."
+    echo ""
+
+    load_model "mlx-community/whisper-medium-mlx" "Whisper STT"
+    load_model "prince-canuma/Kokoro-82M" "Kokoro TTS"
+
+    echo ""
+fi
+
+# Start Docker services
+log "Starting Docker services..."
+docker compose -f docker-compose.apple.yaml up -d
+
+# Wait for services
+printf "${GREEN}[CAAL]${NC} Waiting for services"
+for i in {1..5}; do
+    printf "."
+    sleep 1
+done
+echo -e " ${GREEN}✓${NC}"
+
+echo ""
+echo -e "${CYAN}══════════════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}  CAAL is ready!${NC}"
+echo -e "${CYAN}══════════════════════════════════════════════════════════${NC}"
+echo ""
+echo -e "  ${BOLD}Web interface:${NC}  http://localhost:3000"
+echo -e "  ${BOLD}Stop command:${NC}   ./start-apple.sh --stop"
+echo ""
+echo -e "  ${BOLD}Logs:${NC}"
+echo -e "    mlx-audio:  tail -f $MLX_LOG_FILE"
+echo -e "    agent:      docker compose -f docker-compose.apple.yaml logs -f agent"
+echo ""


### PR DESCRIPTION
## Summary

This PR improves the Apple Silicon experience by adding:

- **`start-apple.sh`**: A unified script to start/stop all services with a single command
- **`README-APPLE.md`**: Comprehensive documentation for Apple Silicon users

## Changes

### start-apple.sh

- Checks prerequisites (Ollama)
- Starts mlx-audio server with Metal acceleration
- Preloads Whisper (STT) and Kokoro (TTS) models with progress feedback
- Starts Docker services (LiveKit, Agent, Frontend)
- Provides `--stop` flag to cleanly shut down everything
- ASCII banner for mlx-CAAL

### README-APPLE.md

- Architecture diagram explaining why native services are needed
- Prerequisites (Ollama, mlx-audio, Docker)
- Step-by-step installation and configuration
- Usage instructions
- Troubleshooting guide
- Memory usage information

## Usage

```bash
# Start
./start-apple.sh

# Stop
./start-apple.sh --stop
```

## Test plan

- [x] Tested on Apple Silicon M4 (24GB)
- [x] Script starts all services correctly
- [x] Script stops all services correctly  
- [x] Voice interaction works end-to-end