### PR TITLE
feat: add French language support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,6 +148,45 @@ services:
       start_period: 60s
 
   # ===========================================================================
+  # Piper/XTTS - TTS for French voices (openedai-speech)
+  # ===========================================================================
+  # Optional: Use with docker compose --profile french up -d
+  # XTTS-v2 with CUDA for low-latency French TTS
+  # Piper voices available as fallback (tts-1 model)
+  piper:
+    profiles:
+      - french
+    image: ghcr.io/matatonic/openedai-speech:latest
+    container_name: caal-piper
+    ports:
+      - "${PIPER_PORT:-8001}:8000"
+    volumes:
+      - piper-voices:/app/voices
+      - ./piper-config:/app/config
+    environment:
+      - TTS_HOME=/app/voices
+      # Use XTTS for tts-1-hd (GPU accelerated), Piper for tts-1 (CPU)
+      - DEFAULT_TTS_MODEL=xtts
+      # CUDA device for XTTS
+      - XTTS_DEVICE=cuda
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    restart: unless-stopped
+    networks:
+      - caal-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
+
+  # ===========================================================================
   # Frontend - Next.js Web Interface
   # ===========================================================================
   frontend:
@@ -222,3 +261,5 @@ volumes:
     name: caal-speaches-cache
   kokoro-cache:
     name: caal-kokoro-cache
+  piper-voices:
+    name: caal-piper-voices

--- a/piper-config/voice_to_speaker.yaml
+++ b/piper-config/voice_to_speaker.yaml
@@ -1,0 +1,41 @@
+tts-1:
+  # English voices from LibriTTS
+  alloy:
+    model: voices/en_US-libritts_r-medium.onnx
+    speaker: 79
+  echo:
+    model: voices/en_US-libritts_r-medium.onnx
+    speaker: 134
+  fable:
+    model: voices/en_GB-northern_english_male-medium.onnx
+    speaker:
+  onyx:
+    model: voices/en_US-libritts_r-medium.onnx
+    speaker: 159
+  nova:
+    model: voices/en_US-libritts_r-medium.onnx
+    speaker: 107
+  shimmer:
+    model: voices/en_US-libritts_r-medium.onnx
+    speaker: 163
+  # French voices from Piper
+  fr_FR-siwis-medium:
+    model: voices/fr_FR-siwis-medium.onnx
+    speaker:
+  fr_FR-tom-medium:
+    model: voices/fr_FR-tom-medium.onnx
+    speaker:
+tts-1-hd:
+  # XTTS voices - GPU accelerated with voice cloning
+  alloy:
+    model: xtts
+    speaker: voices/alloy.wav
+  # French voices for XTTS
+  # Note: XTTS can clone any voice from a ~10-30s reference audio
+  # For now, we use the same model with built-in French language support
+  fr_FR-siwis-medium:
+    model: xtts
+    speaker: voices/fr_siwis.wav
+  fr_FR-tom-medium:
+    model: xtts
+    speaker: voices/fr_tom.wav


### PR DESCRIPTION
## Summary

Add French language support to CAAL with a complete frontend/backend implementation.

### Frontend
- Add language selector (English/Français) in settings
- Add STT language selector (auto/en/fr)
- Filter voices by selected language
- Show language-specific wake greetings

### Backend
- Add Piper TTS service for French voices (openedai-speech)
- Add language and stt_language settings to settings schema
- Add wake_greetings_fr for French greetings
- Update /voices endpoint to return voices with language tags
- Add TTS router in voice_agent.py to route French to Piper, English to Kokoro
- Add STT language hint support for speech recognition
- Update .env.example with PIPER_URL and PIPER_PORT

### Configuration
- Add piper-config/voice_to_speaker.yaml with French voice mappings
- Add piper-config/pre_process_map.yaml for text preprocessing