### PR TITLE
fix: reload-tools endpoint uses correct MCP server attribute

### DIFF
--- a/src/caal/webhooks.py
+++ b/src/caal/webhooks.py
@@ -187,10 +187,11 @@ async def reload_tools(req: ReloadToolsRequest) -> ReloadToolsResponse:
 
     # Re-discover n8n workflows if MCP is configured
     tool_count = 0
-    if agent._n8n_mcp and agent._n8n_base_url:
+    n8n_mcp = agent._caal_mcp_servers.get("n8n")
+    if n8n_mcp and agent._n8n_base_url:
         try:
             tools, name_map = await n8n.discover_n8n_workflows(
-                agent._n8n_mcp, agent._n8n_base_url
+                n8n_mcp, agent._n8n_base_url
             )
             agent._n8n_workflow_tools = tools
             agent._n8n_workflow_name_map = name_map


### PR DESCRIPTION
## Summary
- Fix AttributeError when pressing reload tools button in frontend
- The endpoint was referencing `agent._n8n_mcp` which was removed in commit 2aa0d1e when multi-MCP support was added
- Now correctly retrieves n8n MCP client from `agent._caal_mcp_servers` dict

## Test plan
- [x] Start agent with n8n MCP configured
- [x] Connect via frontend
- [x] Press reload tools button
- [x] Verify no error in agent logs and tools are reloaded

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)