### PR TITLE
feat(llm): add OpenAI-compatible LLM provider

### DIFF
--- a/src/caal/llm/providers/__init__.py
+++ b/src/caal/llm/providers/__init__.py
@@ -1,12 +1,13 @@
 """LLM provider implementations for CAAL.
 
 This package provides a unified interface for different LLM backends,
-enabling CAAL to work with Ollama, Groq, and potentially other providers
-while sharing common tool orchestration logic.
+enabling CAAL to work with Ollama, Groq, OpenAI-compatible servers,
+and potentially other providers while sharing common tool orchestration logic.
 
 Providers:
     - OllamaProvider: Local Ollama with think parameter support
     - GroqProvider: Groq cloud API
+    - OpenAIProvider: Any OpenAI-compatible endpoint (LM Studio, vLLM, LocalAI, etc.)
 
 Example:
     >>> from caal.llm.providers import create_provider
@@ -16,6 +17,9 @@ Example:
     >>>
     >>> # Create Groq provider
     >>> provider = create_provider("groq", model="llama-3.3-70b-versatile")
+    >>>
+    >>> # Create OpenAI-compatible provider
+    >>> provider = create_provider("openai", model="my-model", base_url="http://localhost:8080/v1")
 """
 
 from __future__ import annotations
@@ -27,6 +31,7 @@ from typing import Any
 from .base import LLMProvider, LLMResponse, ToolCall
 from .groq_provider import GroqProvider
 from .ollama_provider import OllamaProvider
+from .openai_provider import OpenAIProvider
 
 __all__ = [
     "LLMProvider",
@@ -34,6 +39,7 @@ __all__ = [
     "ToolCall",
     "OllamaProvider",
     "GroqProvider",
+    "OpenAIProvider",
     "create_provider",
 ]
 
@@ -47,7 +53,7 @@ def create_provider(
     """Factory function to create an LLM provider by name.
 
     Args:
-        provider_name: Provider identifier ("ollama" or "groq")
+        provider_name: Provider identifier ("ollama", "groq", or "openai")
         **kwargs: Provider-specific configuration options
 
     Returns:
@@ -63,6 +69,11 @@ def create_provider(
         ...     think=False,
         ...     temperature=0.7,
         ... )
+        >>> provider = create_provider(
+        ...     "openai",
+        ...     model="my-model",
+        ...     base_url="http://localhost:8080/v1",
+        ... )
     """
     provider_name = provider_name.lower()
 
@@ -70,10 +81,12 @@ def create_provider(
         return OllamaProvider(**kwargs)
     elif provider_name == "groq":
         return GroqProvider(**kwargs)
+    elif provider_name == "openai":
+        return OpenAIProvider(**kwargs)
     else:
         raise ValueError(
             f"Unknown LLM provider: {provider_name}. "
-            f"Supported providers: ollama, groq"
+            f"Supported providers: ollama, groq, openai"
         )
 
 
@@ -85,9 +98,11 @@ def create_provider_from_settings(settings: dict[str, Any]) -> LLMProvider:
 
     Args:
         settings: Runtime settings dict with keys like:
-            - llm_provider: "ollama" or "groq"
-            - model: Ollama model name
+            - llm_provider: "ollama", "groq", or "openai"
+            - ollama_model: Ollama model name
             - groq_model: Groq model name
+            - openai_model: OpenAI-compatible model name
+            - openai_host: OpenAI-compatible server URL
             - temperature: Sampling temperature
             - num_ctx: Context window size (Ollama only)
 
@@ -117,8 +132,18 @@ def create_provider_from_settings(settings: dict[str, Any]) -> LLMProvider:
             api_key=api_key,
             temperature=settings.get("temperature", 0.7),
         )
+    elif provider_name == "openai":
+        # OpenAI-compatible provider for LM Studio, vLLM, LocalAI, etc.
+        base_url = settings.get("openai_host") or os.environ.get("OPENAI_COMPAT_HOST")
+        api_key = settings.get("openai_api_key") or os.environ.get("OPENAI_COMPAT_API_KEY")
+        return OpenAIProvider(
+            model=settings.get("openai_model", "default"),
+            base_url=base_url,
+            api_key=api_key,
+            temperature=settings.get("temperature", 0.7),
+        )
     else:
         raise ValueError(
             f"Unknown LLM provider: {provider_name}. "
-            f"Supported providers: ollama, groq"
+            f"Supported providers: ollama, groq, openai"
         )

--- a/src/caal/llm/providers/openai_provider.py
+++ b/src/caal/llm/providers/openai_provider.py
@@ -1,0 +1,216 @@
+"""OpenAI-compatible LLM provider implementation.
+
+Provides integration with any OpenAI-compatible API endpoint, enabling CAAL
+to work with inference servers like LM Studio, vLLM, LocalAI, FastFlowLM,
+text-generation-webui, and others.
+
+Uses the official openai Python library for async API calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from openai import AsyncOpenAI
+
+from .base import LLMProvider, LLMResponse, ToolCall
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+__all__ = ["OpenAIProvider"]
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(LLMProvider):
+    """OpenAI-compatible LLM provider.
+
+    Works with any server implementing the OpenAI chat completions API,
+    including LM Studio, vLLM, LocalAI, FastFlowLM, and text-generation-webui.
+
+    Features:
+        - Async API calls via openai.AsyncOpenAI
+        - Tool/function calling support (requires model support)
+        - Optional API key authentication
+
+    Args:
+        model: Model name as recognized by the server
+        base_url: Server URL (e.g., "http://localhost:8080/v1")
+        api_key: Optional API key (some servers don't require auth)
+        temperature: Sampling temperature (0.0-2.0)
+        max_tokens: Maximum tokens to generate
+    """
+
+    def __init__(
+        self,
+        model: str,
+        base_url: str,
+        api_key: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> None:
+        self._model = model
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key or os.environ.get("OPENAI_COMPAT_API_KEY")
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+
+        if not self._base_url:
+            raise ValueError(
+                "Base URL required for OpenAI-compatible provider. "
+                "Set OPENAI_COMPAT_HOST environment variable or pass base_url parameter."
+            )
+
+        # Use "not-needed" as placeholder if no API key - some servers require
+        # the header to be present even if they don't validate it
+        self._client = AsyncOpenAI(
+            base_url=self._base_url,
+            api_key=self._api_key or "not-needed",
+        )
+
+        logger.debug(f"OpenAIProvider initialized: {model} at {base_url}")
+
+    @property
+    def provider_name(self) -> str:
+        return "openai"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def temperature(self) -> float:
+        return self._temperature
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Execute non-streaming chat completion.
+
+        Args:
+            messages: List of message dicts
+            tools: Optional tool definitions
+            **kwargs: Additional options
+
+        Returns:
+            Normalized LLMResponse
+        """
+        request_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": messages,
+            "temperature": self._temperature,
+            "max_tokens": self._max_tokens,
+            "stream": False,
+        }
+
+        if tools:
+            request_kwargs["tools"] = tools
+            request_kwargs["tool_choice"] = "auto"
+
+        response = await self._client.chat.completions.create(**request_kwargs)
+
+        # Extract from OpenAI response format
+        message = response.choices[0].message
+
+        # Extract tool calls if present
+        tool_calls: list[ToolCall] = []
+        if message.tool_calls:
+            for tc in message.tool_calls:
+                # OpenAI returns arguments as JSON string
+                args = self.parse_tool_arguments(tc.function.arguments)
+                tool_calls.append(
+                    ToolCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=args,
+                    )
+                )
+
+        return LLMResponse(content=message.content, tool_calls=tool_calls)
+
+    async def chat_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Execute streaming chat completion.
+
+        Args:
+            messages: List of message dicts
+            tools: Optional tool definitions (for validation of tool_calls in history)
+            **kwargs: Additional options
+
+        Yields:
+            String chunks of response content
+        """
+        request_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": messages,
+            "temperature": self._temperature,
+            "max_tokens": self._max_tokens,
+            "stream": True,
+        }
+
+        # Include tools if provided (for validation of tool_calls in message history)
+        # Set tool_choice="none" to prevent tool calls in streaming mode
+        if tools:
+            request_kwargs["tools"] = tools
+            request_kwargs["tool_choice"] = "none"
+
+        stream = await self._client.chat.completions.create(**request_kwargs)
+
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
+
+    def parse_tool_arguments(self, arguments: Any) -> dict[str, Any]:
+        """Parse tool arguments from JSON string.
+
+        OpenAI-compatible APIs return tool call arguments as a JSON string.
+
+        Args:
+            arguments: JSON string or dict of arguments
+
+        Returns:
+            Parsed arguments dict
+        """
+        if isinstance(arguments, str):
+            try:
+                return json.loads(arguments)
+            except json.JSONDecodeError:
+                logger.warning(f"Failed to parse tool arguments: {arguments}")
+                return {}
+        if isinstance(arguments, dict):
+            return arguments
+        return {}
+
+    def format_tool_result(
+        self,
+        content: str,
+        tool_call_id: str | None,
+        tool_name: str,
+    ) -> dict[str, Any]:
+        """Format tool result message for OpenAI-compatible API.
+
+        Args:
+            content: Tool execution result as string
+            tool_call_id: ID of the tool call being responded to
+            tool_name: Name of the tool that was called
+
+        Returns:
+            Message dict for OpenAI API
+        """
+        return {
+            "role": "tool",
+            "content": content,
+            "tool_call_id": tool_call_id,
+            "name": tool_name,
+        }

--- a/src/caal/settings.py
+++ b/src/caal/settings.py
@@ -41,7 +41,7 @@ DEFAULT_SETTINGS = {
     "language": "en",  # ISO 639-1: "en" | "fr" | "it"
     # Provider settings (UI sets both together, but stored separately for power users)
     "stt_provider": "speaches",  # "speaches" | "groq"
-    "llm_provider": "ollama",  # "ollama" | "groq"
+    "llm_provider": "ollama",  # "ollama" | "groq" | "openai"
     "tts_provider": "kokoro",  # "kokoro" | "piper"
     # TTS settings - voice selection (Kokoro uses voice param, Piper bakes voice into model)
     "tts_voice_kokoro": "am_puck",
@@ -54,6 +54,10 @@ DEFAULT_SETTINGS = {
     # Groq settings
     "groq_api_key": "",  # API key from console.groq.com
     "groq_model": "llama-3.3-70b-versatile",
+    # OpenAI-compatible settings (LM Studio, vLLM, LocalAI, FastFlowLM, etc.)
+    "openai_host": "",  # Server URL (e.g., http://localhost:8080/v1)
+    "openai_model": "",  # Model name as recognized by the server
+    "openai_api_key": "",  # Optional - some servers don't require auth
     # Home Assistant integration
     "hass_enabled": False,
     "hass_host": "",
@@ -163,6 +167,14 @@ def _migrate_env_to_settings(settings: dict) -> dict:
         settings["n8n_url"] = n8n_url
     if n8n_token := os.getenv("N8N_MCP_TOKEN"):
         settings["n8n_token"] = n8n_token
+
+    # OpenAI-compatible provider settings
+    if openai_host := os.getenv("OPENAI_COMPAT_HOST"):
+        settings["openai_host"] = openai_host
+    if openai_model := os.getenv("OPENAI_COMPAT_MODEL"):
+        settings["openai_model"] = openai_model
+    if openai_api_key := os.getenv("OPENAI_COMPAT_API_KEY"):
+        settings["openai_api_key"] = openai_api_key
 
     return settings
 


### PR DESCRIPTION
## Summary

Add support for generic OpenAI-compatible LLM endpoints, enabling CAAL to work with inference servers like LM Studio, vLLM, LocalAI, FastFlowLM, and text-generation-webui.

Closes #29

## Changes

- **New provider:** `src/caal/llm/providers/openai_provider.py`
  - Uses official `openai` Python library with `AsyncOpenAI`
  - Supports tool/function calling (requires model support)
  - Optional API key authentication

- **Updated:** `src/caal/llm/providers/__init__.py`
  - Added `OpenAIProvider` export
  - Updated `create_provider()` and `create_provider_from_settings()`

- **Updated:** `src/caal/settings.py`
  - Added `openai_host`, `openai_model`, `openai_api_key` settings
  - Added env var fallbacks: `OPENAI_COMPAT_HOST`, `OPENAI_COMPAT_MODEL`, `OPENAI_COMPAT_API_KEY`

## Configuration

```python
# Via settings
settings = {
    "llm_provider": "openai",
    "openai_host": "http://localhost:8080/v1",
    "openai_model": "my-model",
    "openai_api_key": "",  # Optional
}

# Via environment variables
OPENAI_COMPAT_HOST=http://localhost:8080/v1
OPENAI_COMPAT_MODEL=my-model
OPENAI_COMPAT_API_KEY=optional-key
```

## Compatibility

Should work with any server implementing `/v1/chat/completions`:
- LM Studio
- vLLM
- LocalAI
- FastFlowLM (AMD NPU)
- text-generation-webui

## Test plan

- [ ] Test with LM Studio
- [ ] Test with vLLM
- [ ] Verify tool calling works
- [ ] Verify streaming works

🤖 Generated with [Claude Code](https://claude.ai/code)