### PR TITLE
feat: auto-trust self-signed certificate & fix SAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ Open `https://YOUR_SERVER_IP:3443` and complete the setup wizard.
 
 HTTPS is enabled by default with auto-generated self-signed certificates. This is required because browsers block microphone access on non-`localhost` HTTP.
 
-For browser-trusted certs (no warnings), use [mkcert](https://github.com/FiloSottile/mkcert):
+To avoid the browser certificate warning, trust the auto-generated cert:
+```bash
+./trust-cert.sh
+```
+This works on macOS and Linux (Debian/Ubuntu, RHEL/Fedora, Chrome, Firefox). Pass `--yes` to skip the confirmation prompt. On Apple Silicon, `start-apple.sh` runs it automatically.
+
+Alternatively, for browser-trusted certs use [mkcert](https://github.com/FiloSottile/mkcert):
 ```bash
 mkcert -install && mkcert 192.168.1.100
 mkdir -p certs && mv 192.168.1.100.pem certs/server.crt && mv 192.168.1.100-key.pem certs/server.key

--- a/docker-compose.apple.yaml
+++ b/docker-compose.apple.yaml
@@ -181,7 +181,8 @@ services:
           openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
             -keyout /etc/nginx/certs/server.key \
             -out /etc/nginx/certs/server.crt \
-            -subj "/CN=$${CAAL_HOST_IP:-localhost}" 2>/dev/null
+            -subj "/CN=$${CAAL_HOST_IP:-localhost}" \
+            -addext "subjectAltName=DNS:localhost,IP:$${CAAL_HOST_IP:-127.0.0.1},IP:127.0.0.1" 2>/dev/null
           echo "Self-signed certificate generated for $${CAAL_HOST_IP:-localhost}"
         else
           echo "Using existing certificate"

--- a/docker-compose.cpu.yaml
+++ b/docker-compose.cpu.yaml
@@ -163,7 +163,8 @@ services:
           openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
             -keyout /etc/nginx/certs/server.key \
             -out /etc/nginx/certs/server.crt \
-            -subj "/CN=$${CAAL_HOST_IP:-localhost}" 2>/dev/null
+            -subj "/CN=$${CAAL_HOST_IP:-localhost}" \
+            -addext "subjectAltName=DNS:localhost,IP:$${CAAL_HOST_IP:-127.0.0.1},IP:127.0.0.1" 2>/dev/null
           echo "Self-signed certificate generated for $${CAAL_HOST_IP:-localhost}"
         else
           echo "Using existing certificate"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -198,7 +198,8 @@ services:
           openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
             -keyout /etc/nginx/certs/server.key \
             -out /etc/nginx/certs/server.crt \
-            -subj "/CN=$${CAAL_HOST_IP:-localhost}" 2>/dev/null
+            -subj "/CN=$${CAAL_HOST_IP:-localhost}" \
+            -addext "subjectAltName=DNS:localhost,IP:$${CAAL_HOST_IP:-127.0.0.1},IP:127.0.0.1" 2>/dev/null
           echo "Self-signed certificate generated for $${CAAL_HOST_IP:-localhost}"
         else
           echo "Using existing certificate"

--- a/start-apple.sh
+++ b/start-apple.sh
@@ -233,6 +233,11 @@ fi
 log "Starting Docker services..."
 docker compose -f docker-compose.apple.yaml up -d
 
+# Trust certificate if not already trusted
+if [ -f "$SCRIPT_DIR/trust-cert.sh" ]; then
+    "$SCRIPT_DIR/trust-cert.sh"
+fi
+
 # Wait for services
 printf "${GREEN}[CAAL]${NC} Waiting for services"
 for i in {1..5}; do

--- a/trust-cert.sh
+++ b/trust-cert.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# trust-cert.sh — Install CAAL's self-signed certificate into the OS/browser trust store.
+# Usage: ./trust-cert.sh [--yes]
+
+set -euo pipefail
+
+CERT="./certs/server.crt"
+AUTO_YES=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --yes|-y) AUTO_YES=true ;;
+    esac
+done
+
+if [ ! -f "$CERT" ]; then
+    echo "No certificate found at $CERT — start the stack first so it is generated."
+    exit 0
+fi
+
+if [ "$AUTO_YES" = false ]; then
+    printf "Trust the CAAL self-signed certificate so browsers stop showing warnings? [y/N] "
+    read -r answer
+    case "$answer" in
+        [Yy]*) ;;
+        *) echo "Skipped."; exit 0 ;;
+    esac
+fi
+
+OS="$(uname -s)"
+
+case "$OS" in
+    Darwin)
+        echo "Installing certificate into macOS System Keychain..."
+        sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain "$CERT"
+        echo "Done — certificate trusted on macOS."
+        ;;
+
+    Linux)
+        # System trust store
+        if [ -d /usr/local/share/ca-certificates ]; then
+            echo "Installing certificate (Debian/Ubuntu)..."
+            sudo cp "$CERT" /usr/local/share/ca-certificates/caal.crt
+            sudo update-ca-certificates
+        elif [ -d /etc/pki/ca-trust/source/anchors ]; then
+            echo "Installing certificate (RHEL/Fedora)..."
+            sudo cp "$CERT" /etc/pki/ca-trust/source/anchors/caal.pem
+            sudo update-ca-trust
+        else
+            echo "Warning: could not detect CA trust directory. Skipping system trust."
+        fi
+
+        # Chrome (NSS database)
+        if command -v certutil >/dev/null 2>&1; then
+            NSSDB="$HOME/.pki/nssdb"
+            if [ -d "$NSSDB" ]; then
+                echo "Adding certificate to Chrome trust store..."
+                certutil -d sql:"$NSSDB" -A -t "C,," -n "CAAL" -i "$CERT"
+            fi
+
+            # Firefox profiles
+            for profile in "$HOME"/.mozilla/firefox/*.default*; do
+                if [ -d "$profile" ]; then
+                    echo "Adding certificate to Firefox profile $(basename "$profile")..."
+                    certutil -d sql:"$profile" -A -t "C,," -n "CAAL" -i "$CERT"
+                fi
+            done
+        else
+            echo "Tip: install certutil (libnss3-tools) to also trust the cert in Chrome/Firefox."
+        fi
+
+        echo "Done — certificate trusted on Linux."
+        ;;
+
+    *)
+        echo "Unsupported OS: $OS. Please import $CERT manually."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Add `trust-cert.sh` — multi-OS script to install the self-signed cert into the trust store (macOS Keychain, Debian/Ubuntu, RHEL/Fedora, Chrome/Firefox via certutil)
- Fix missing SubjectAltName in all 3 docker-compose files so Chrome accepts the cert
- `start-apple.sh` now calls `trust-cert.sh` automatically after Docker startup
- Document `trust-cert.sh` in README HTTPS section

Closes #58

## Test plan

- [x] Delete `./certs/`, restart stack — verify new cert has SAN: `openssl x509 -in certs/server.crt -noout -ext subjectAltName`
- [x] Run `./trust-cert.sh` on macOS — verify: `security verify-cert -c certs/server.crt`
- [x] Open `https://localhost:3443` — no browser warning after trust
- [x] Test `./trust-cert.sh --yes` (non-interactive mode)
- [x] Test on Linux (Debian/Ubuntu or RHEL/Fedora)