### PR TITLE
feat(docker): configurable GPU IDs for Speaches and Kokoro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,10 @@ SPEACHES_URL=http://localhost:8000
 # Whisper model for STT (full HuggingFace name)
 WHISPER_MODEL=Systran/faster-whisper-medium
 
+# GPU ID to bind Speaches to (multi-GPU hosts). Default: 0
+# Find IDs with: nvidia-smi -L
+#SPEACHES_GPU_ID=0
+
 # =============================================================================
 # TTS Configuration (Kokoro via remsky/kokoro-fastapi)
 # =============================================================================
@@ -82,6 +86,10 @@ KOKORO_URL=http://localhost:8880
 # Kokoro voice for TTS
 # Options: af_heart, af_bella, af_sarah (female), am_adam, am_puck (male)
 TTS_VOICE=am_puck
+
+# GPU ID to bind Kokoro to (multi-GPU hosts). Default: 0
+# Set to a different ID than your local Ollama (CUDA_VISIBLE_DEVICES) to avoid OOM.
+#KOKORO_GPU_ID=0
 
 # =============================================================================
 # LLM Configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,7 +108,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              device_ids: ['${SPEACHES_GPU_ID:-0}']
               capabilities: [gpu]
     restart: unless-stopped
     networks:
@@ -137,7 +137,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              device_ids: ['${KOKORO_GPU_ID:-0}']
               capabilities: [gpu]
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary
- Replaces hardcoded `count: 1` GPU reservations on the Speaches and Kokoro services with `device_ids: ['${SPEACHES_GPU_ID:-0}']` / `['${KOKORO_GPU_ID:-0}']`.
- Adds `SPEACHES_GPU_ID` and `KOKORO_GPU_ID` to `.env.example` (commented out, default 0 — fully backward-compatible on single-GPU hosts).
- Motivation: on multi-GPU hosts where Ollama is pinned to GPU 0 via `CUDA_VISIBLE_DEVICES`, Kokoro and Speaches default to the same card and can OOM at startup. This lets users route TTS/STT to a different GPU without forking the compose file.

## Notes
- Ollama runs on the host (outside this stack), so its GPU selection stays where it is — in the systemd unit / launcher via `CUDA_VISIBLE_DEVICES`.
- `docker-compose.cpu.yaml` and `docker-compose.apple.yaml` are untouched (no GPU reservations there).

## Test plan
- [ ] `docker compose config --quiet` passes with defaults
- [ ] `docker compose up -d speaches kokoro` boots on a single-GPU host with no env var set (regression check)
- [ ] On a multi-GPU host with `KOKORO_GPU_ID=1`, confirm `nvidia-smi` shows the kokoro container on GPU 1
- [ ] Same for `SPEACHES_GPU_ID=1`
- [ ] Confirm OOM no longer occurs when Ollama holds GPU 0 and Kokoro is moved to GPU 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)